### PR TITLE
Updates scenes for new API

### DIFF
--- a/project/blocky_terrain/main.tscn
+++ b/project/blocky_terrain/main.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=18 format=2]
 
-[ext_resource path="res://blocky_terrain/provider_image.tres" type="VoxelProviderImage" id=1]
+[ext_resource path="res://blocky_terrain/provider_image.tres" type="VoxelStreamImage" id=1]
 [ext_resource path="res://blocky_terrain/terrain_material.tres" type="Material" id=2]
 [ext_resource path="res://blocky_terrain/terrain_marerial_transparent.tres" type="Material" id=3]
-[ext_resource path="res://blocky_terrain/character_avatar.tscn" type="PackedScene" id=4]
+[ext_resource path="res://axes.tscn" type="PackedScene" id=4]
 [ext_resource path="res://grid.gd" type="Script" id=5]
-[ext_resource path="res://axes.tscn" type="PackedScene" id=6]
+[ext_resource path="res://blocky_terrain/character_avatar.tscn" type="PackedScene" id=6]
 [ext_resource path="res://blocky_terrain/profiling_gui.gd" type="Script" id=8]
 [ext_resource path="res://blocky_terrain/debug3d.gd" type="Script" id=9]
 
@@ -98,11 +98,11 @@ size = 8
 transform = Transform( -0.985468, 0.124099, -0.11598, 0.0154004, 0.745271, 0.666584, 0.169159, 0.655111, -0.736353, 1.51966, 19.7004, 14.0879 )
 directional_shadow_normal_bias = 0.1
 
-[node name="CharacterAvatar" parent="." instance=ExtResource( 4 )]
+[node name="CharacterAvatar" parent="." instance=ExtResource( 6 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 58.0914, 17 )
 terrain = NodePath("../VoxelTerrain")
 
-[node name="axes" parent="." instance=ExtResource( 6 )]
+[node name="axes" parent="." instance=ExtResource( 4 )]
 visible = false
 
 [node name="ProfilingInfo" type="Label" parent="."]

--- a/project/blocky_terrain/profiling_gui.gd
+++ b/project/blocky_terrain/profiling_gui.gd
@@ -14,9 +14,9 @@ func _process(delta):
 
 	var s = str("Dynamic memory: ", _format_memory(dm), \
 		"\nStatic memory: ", _format_memory(sm), \
-		"\nProvider: ", stats.provider.remaining_blocks, \
-		"\nUpdater (thread): ", stats.updater.remaining_blocks, \
 		"\nUpdater (main thread): ", stats.updater.remaining_main_thread_blocks)
+		#"\nProvider: ", stats.provider.remaining_blocks, \
+		#"\nUpdater (thread): ", stats.updater.remaining_blocks, \
 
 	set_text(s)
 

--- a/project/blocky_terrain/provider_image.tres
+++ b/project/blocky_terrain/provider_image.tres
@@ -1,11 +1,6 @@
-[gd_resource type="VoxelProviderImage" load_steps=2 format=2]
+[gd_resource type="VoxelStreamImage" load_steps=2 format=2]
 
 [ext_resource path="res://blocky_terrain/noise_distorted.png" type="Image" id=1]
 
-
 [resource]
-
 image = ExtResource( 1 )
-channel = 0
-_sections_unfolded = [ "image" ]
-

--- a/project/dmc_terrain/main.tscn
+++ b/project/dmc_terrain/main.tscn
@@ -3,8 +3,8 @@
 [ext_resource path="res://dmc_terrain/interaction.gd" type="Script" id=1]
 [ext_resource path="res://dmc_terrain/dmc_terrain_material.tres" type="Material" id=2]
 [ext_resource path="res://blocky_terrain/noise_distorted.png" type="Image" id=3]
-[ext_resource path="res://spectator_avatar.tscn" type="PackedScene" id=4]
-[ext_resource path="res://axes.tscn" type="PackedScene" id=5]
+[ext_resource path="res://axes.tscn" type="PackedScene" id=4]
+[ext_resource path="res://spectator_avatar.tscn" type="PackedScene" id=5]
 
 [sub_resource type="ProceduralSky" id=1]
 sky_top_color = Color( 0.388235, 0.533333, 0.615686, 1 )
@@ -15,7 +15,7 @@ background_mode = 2
 background_sky = SubResource( 1 )
 ambient_light_sky_contribution = 0.5
 
-[sub_resource type="VoxelProviderImage" id=3]
+[sub_resource type="VoxelStreamImage" id=3]
 image = ExtResource( 3 )
 channel = 1
 
@@ -48,9 +48,9 @@ transform = Transform( 0.912457, -0.352848, 0.207171, 0, 0.506317, 0.862348, -0.
 shadow_enabled = true
 shadow_bias = 0.05
 
-[node name="Axes" parent="." instance=ExtResource( 5 )]
+[node name="Axes" parent="." instance=ExtResource( 4 )]
 
-[node name="SpectatorAvatar" parent="." instance=ExtResource( 4 )]
+[node name="SpectatorAvatar" parent="." instance=ExtResource( 5 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 19.9349, 17.285 )
 speed = 20.0
 

--- a/project/dmc_test/main.gd
+++ b/project/dmc_test/main.gd
@@ -15,7 +15,7 @@ var _iso_scale = 1.0
 
 func _ready():
 	
-	_mesher.set_octree_mode(VoxelMesherDMC.OCTREE_NONE)
+	_mesher.set_simplify_mode(VoxelMesherDMC.SIMPLIFY_NONE)
 
 	_voxels.create(20, 20, 20)
 	


### PR DESCRIPTION
## Blocky Terrain
Works

GDScript stats had to be commented out:
```
"\nProvider: ", stats.provider.remaining_blocks, \
"\nUpdater (thread): ", stats.updater.remaining_blocks, \

```

## DMC Terrain (smooth)
Works

## DMC Test (cube w/ blue sphere)
Works


## Transvoxel
Scene opens, but does not run because of OsnNoise not migrated to opensimplexnoise.
Does not work in the old API either.
Can be addressed in a different PR.


## New scene
New scene using a voxelterrain from both a noise map, or using opensimplexnoise work.


## Notes
* get_statistics() in C++ still has provider as a dictionary element. 
* VoxelTerrain in Godot has a member called Provider.
Are these intended to be left? If changed, they might need another update here.

fixes #62 