### PR TITLE
Fix the voxels in blocky_game cannot be displayed normally

### DIFF
--- a/project/blocky_game/generator/generator.gd
+++ b/project/blocky_game/generator/generator.gd
@@ -74,7 +74,7 @@ func _get_used_channels_mask() -> int:
 
 func _generate_block(buffer: VoxelBuffer, origin_in_voxels: Vector3, lod: int):
 	# Saves from this demo used 8-bit, which is no longer the default
-	buffer.set_channel_depth(_CHANNEL, VoxelBuffer.DEPTH_8_BIT)
+	# buffer.set_channel_depth(_CHANNEL, VoxelBuffer.DEPTH_8_BIT)
 
 	# Assuming input is cubic in our use case (it doesn't have to be!)
 	var block_size := int(buffer.get_size().x)


### PR DESCRIPTION
#87 

Now, The voxels can be displayed normally and godot doesn't report any more errors.

Thanks @Zylann 