### PR TITLE
Rewrite create_wireframe_cube

### DIFF
--- a/project/blocky_game/blocks/voxel_library.tres
+++ b/project/blocky_game/blocks/voxel_library.tres
@@ -88,6 +88,8 @@ mesh = ExtResource("7")
 
 [sub_resource type="VoxelBlockyModelMesh" id="VoxelBlockyModelMesh_ilklx"]
 resource_name = "tall_grass"
+collision_aabbs = Array[AABB]([AABB(0, 0, 0, 1, 1, 1)])
+collision_mask = 2
 material_override_0 = ExtResource("6_7k7uf")
 collision_enabled_0 = true
 mesh = ExtResource("8")

--- a/project/blocky_game/player/avatar_interaction.gd
+++ b/project/blocky_game/player/avatar_interaction.gd
@@ -34,6 +34,8 @@ const _hotbar_keys = {
 @onready var _water_updater : WaterUpdater
 @onready var _terrain : VoxelTerrain = get_node("/root/Main/Game/VoxelTerrain")
 
+const _library := preload("res://blocky_game/blocks/voxel_library.tres")
+
 var _terrain_tool : VoxelTool = null
 var _cursor : MeshInstance3D = null
 var _action_place := false
@@ -42,12 +44,10 @@ var _action_pick := false
 
 
 func _ready():
-	var mesh := Util.create_wirecube_mesh(Color(0,0,0))
 	var mesh_instance := MeshInstance3D.new()
-	mesh_instance.mesh = mesh
 	if cursor_material != null:
 		mesh_instance.material_override = cursor_material
-	mesh_instance.set_scale(Vector3(1,1,1)*1.01)
+	mesh_instance.set_scale(Vector3(1,1,1)*1.001)
 	_cursor = mesh_instance
 	
 	_terrain.add_child(_cursor)
@@ -73,6 +73,9 @@ func _physics_process(_delta):
 	
 	var hit := _get_pointed_voxel()
 	if hit != null:
+		var hit_raw_id := _terrain_tool.get_voxel(hit.position)
+		var model := _library.get_model(hit_raw_id)
+		_cursor.mesh = Util.create_wireframe_mesh(model)
 		_cursor.show()
 		_cursor.set_position(hit.position)
 		DDD.set_text("Pointed voxel", str(hit.position))

--- a/project/common/util.gd
+++ b/project/common/util.gd
@@ -1,40 +1,31 @@
 
-static func create_wirecube_mesh(color = Color(1,1,1)) -> ArrayMesh:
-	var positions = PackedVector3Array([
-		Vector3(0, 0, 0),
-		Vector3(1, 0, 0),
-		Vector3(1, 0, 1),
-		Vector3(0, 0, 1),
-		Vector3(0, 1, 0),
-		Vector3(1, 1, 0),
-		Vector3(1, 1, 1),
-		Vector3(0, 1, 1)
-	])
-	var colors = PackedColorArray([
-		color, color, color, color,
-		color, color, color, color,
-	])
-	var indices = PackedInt32Array([
-		0, 1,
-		1, 2,
-		2, 3,
-		3, 0,
-
-		4, 5,
-		5, 6,
-		6, 7,
-		7, 4,
-
-		0, 4,
-		1, 5,
-		2, 6,
-		3, 7
-	])
+static func create_wireframe_mesh(model: VoxelBlockyModel) -> Mesh:
+	var collision_aabbs := model.collision_aabbs
+	
+	var positions = []
+	for aabb in collision_aabbs:
+		for x in 2:
+			for y in 2:
+				for z in 2:
+					positions.append(aabb.position + aabb.size * Vector3(x, y, z))
+					
+	var colors = []
+	colors.resize(collision_aabbs.size() * 8)
+	colors.fill(Color(1, 1, 1))
+	
+	var indices = []
+	for i in collision_aabbs.size():
+		indices.append_array([
+		0, 1, 0, 4, 1, 5, 4, 5,
+		0, 2, 1, 3, 4, 6, 5, 7,
+		2, 3, 2, 6, 7, 3, 7, 6
+	].map(func(number): return number + 8 * i))
+	
 	var arrays = []
 	arrays.resize(Mesh.ARRAY_MAX)
-	arrays[Mesh.ARRAY_VERTEX] = positions
-	arrays[Mesh.ARRAY_COLOR] = colors
-	arrays[Mesh.ARRAY_INDEX] = indices
+	arrays[Mesh.ARRAY_VERTEX] = PackedVector3Array(positions)
+	arrays[Mesh.ARRAY_COLOR] = PackedColorArray(colors)
+	arrays[Mesh.ARRAY_INDEX] = PackedInt32Array(indices)
 	var mesh = ArrayMesh.new()
 	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_LINES, arrays)
 	return mesh


### PR DESCRIPTION
Rewrite `create_wireframe_cube` to `create_wireframe_mesh`
Now it will be based on model's `collision_aabbs` create wireframe.
In this way, models that are not cubes can be perfectly framed (such as stairs).
