### PR TITLE
Fixed stale library calls

### DIFF
--- a/project/blocky_game/blocks/blocks.gd
+++ b/project/blocky_game/blocks/blocks.gd
@@ -199,7 +199,7 @@ func _create_block(params: Dictionary):
 	
 	for i in len(params.voxels):
 		var vname : String = params.voxels[i]
-		var id := _voxel_library.get_voxel_index_from_name(vname)
+		var id := _voxel_library.get_model_index_from_resource_name(vname)
 		if id == -1:
 			push_error("Could not find voxel named {0}".format([vname]))
 		assert(id != -1)

--- a/project/blocky_game/generator/test_tree_generator.gd
+++ b/project/blocky_game/generator/test_tree_generator.gd
@@ -27,8 +27,8 @@ func _input(event):
 
 func _generate():
 	var tree_generator := TreeGenerator.new()
-	tree_generator.log_type = VoxelLibraryResource.get_voxel_index_from_name("log_y")
-	tree_generator.leaves_type = VoxelLibraryResource.get_voxel_index_from_name("dirt")
+	tree_generator.log_type = VoxelLibraryResource.get_model_index_from_resource_name("log_y")
+	tree_generator.leaves_type = VoxelLibraryResource.get_model_index_from_resource_name("dirt")
 	
 	var s = tree_generator.generate()
 

--- a/project/blocky_game/random_ticks.gd
+++ b/project/blocky_game/random_ticks.gd
@@ -47,7 +47,7 @@ var _tall_grass_type : int
 
 
 func _ready():
-	_tall_grass_type = VoxelLibraryResource.get_voxel_index_from_name("tall_grass")
+	_tall_grass_type = VoxelLibraryResource.get_model_index_from_resource_name("tall_grass")
 	_voxel_tool.set_channel(VoxelBuffer.CHANNEL_TYPE)
 
 


### PR DESCRIPTION
New release of [Voxel Tools for Godot](https://github.com/Zylann/godot_voxel) changed the library calls from `get_voxel_index_from_name` to `get_model_index_from_resource_name`.

Following changes make this project run with the newest release of Godot + Voxel Tools [Godot 4.3.stable.custom_build](https://github.com/Zylann/godot_voxel/releases/tag/v1.3.0).