### PR TITLE
Add all internal uniforms to their own group

### DIFF
--- a/project/addons/zylann.voxel/shaders/lod_fade.gdshaderinc
+++ b/project/addons/zylann.voxel/shaders/lod_fade.gdshaderinc
@@ -1,7 +1,8 @@
 
 // These uniforms are assigned internally by the voxel engine.
+group_uniforms voxel;
 uniform vec2 u_lod_fade;
-
+group_uniforms;
 
 float get_hash(vec2 c) {
 	return fract(sin(dot(c.xy, vec2(12.9898,78.233))) * 43758.5453);

--- a/project/addons/zylann.voxel/shaders/transvoxel.gdshaderinc
+++ b/project/addons/zylann.voxel/shaders/transvoxel.gdshaderinc
@@ -1,7 +1,8 @@
 
 // This uniform is assigned internally by the voxel engine.
+group_uniforms voxel;
 uniform int u_transition_mask;
-
+group_uniforms;
 
 float get_transvoxel_secondary_factor(int idata) {
 	int cell_border_mask = (idata >> 0) & 63; // Which sides the cell is touching

--- a/project/addons/zylann.voxel/shaders/virtual_texturing.gdshaderinc
+++ b/project/addons/zylann.voxel/shaders/virtual_texturing.gdshaderinc
@@ -3,6 +3,7 @@
 //#define VOXEL_VIRTUAL_TEXTURE_USE_TEXTURE_ARRAY
 
 // These uniforms are assigned internally by the voxel engine.
+group_uniforms voxel;
 // TODO Godot is not binding integer samplers properly.
 // See https://github.com/godotengine/godot/issues/57841
 // TODO Workaround using float texelFetch doesnt't work either...
@@ -25,7 +26,7 @@ uniform int u_voxel_block_size;
 // to query only inside a sub-region.
 // (x, y, z) is offset, (w) is scale.
 uniform vec4 u_voxel_virtual_texture_offset_scale;
-
+group_uniforms;
 
 vec2 pad_uv(vec2 uv, float amount) {
 	return uv * (1.0 - 2.0 * amount) + vec2(amount);


### PR DESCRIPTION
Sets `group_uniform voxel;` for all of the uniforms in shader include files within /addons/zylann.voxel/ folder. This way they will be folded in the inspector by default, getting them out of new users' sight.

**Motivation:**
When I started experimenting with the module and was very noob with shaders I found the amount of shader params displayed a bit overwhelming. Besides, my own uniforms I have been adding to the example shader were harder to find due to resulting clutter. I would be happy if there was a way to just hide some uniforms from appearing in inspector, since these uniforms are service, and are not meant to be tweaked by user anyway, but I found the current solution a good enough alternative. :)